### PR TITLE
Move example to new folder

### DIFF
--- a/example/example.py
+++ b/example/example.py
@@ -1,6 +1,6 @@
 import asyncio
 import os
-from onepassword.client import Client
+from onepassword import Client
 
 async def main():
     # Gets your service account token from the OP_SERVICE_ACCOUNT_TOKEN environment variable.


### PR DESCRIPTION
## Overview

We previously had our example.py in the src folder. This made it such that users downloaded the example together with the package. We don't want that.

## Thought process
Move the example.py in a new example folder which is separate from what gets distributed.

## How to Test

Install the SDK using the guide in the README, copy the example and run it: `python3 example/example.py`