### PR TITLE
Update README.md to remove service account limitation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The 1Password Python SDK offers programmatic access to your secrets in 1Password
 
 ## 🔑 Authentication
 
-1Password SDKs support authentication with [1Password Service Accounts](https://developer.1password.com/docs/service-accounts/get-started/). You can create service accounts if you're an owner or administrator on your team. Otherwise, ask your administrator for a service account token.
+1Password SDKs support authentication with [1Password Service Accounts](https://developer.1password.com/docs/service-accounts/get-started/). 
 
 Before you get started, [create a service account](https://developer.1password.com/docs/service-accounts/get-started/#create-a-service-account) and give it the appropriate permissions in the vaults where the items you want to use with the SDK are saved.
 


### PR DESCRIPTION
This PR updates the README to avoid the service account limitation that previously only allowed service account creation by administrators and owners. Any user and group is now able to create service accounts, so long as their administrator has given them adequate permissions.