### PR TITLE
Improves machine and platform checks and fixes deprecated ruff command in Github validation workflow

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.x'
-          
+
       - name: Test with pytest
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.TEST_SERVICE_ACCOUNT_TOKEN }}
@@ -33,5 +33,5 @@ jobs:
       - name: Lint with Ruff
         run: |
           pip install ruff
-          ruff --output-format=github --exclude=src/onepassword/lib/ .
+          ruff check --output-format=github --exclude=src/onepassword/lib/ .
         continue-on-error: true

--- a/setup.py
+++ b/setup.py
@@ -20,21 +20,19 @@ except ImportError:
 def get_shared_library_data_to_include():
     # Return the correct uniffi C shared library extension for the given platform
     include_path = "lib"
-    if platform.machine().lower() == "x86_64" or platform.machine().lower() == "amd64":
+    machine_type = platform.machine().lower()
+    if machine_type in ["x86_64", "amd64"]:
         include_path = os.path.join(include_path, "x86_64")
-    elif (
-        platform.machine().lower() == "aarch64" or platform.machine().lower() == "arm64"
-    ):
+    elif machine_type in ["aarch64", "arm64"]:
         include_path = os.path.join(include_path, "aarch64")
 
-    c_shared_library_file_name = ""
-    if platform.system() == "Darwin":
-        c_shared_library_file_name = "libop_uniffi_core.dylib"
-    elif platform.system() == "Linux":
-        c_shared_library_file_name = "libop_uniffi_core.so"
-    elif platform.system() == "Windows":
-        c_shared_library_file_name = "op_uniffi_core.dll"
-
+    # Map current platform to the correct shared library file name
+    platform_to_lib = {
+        "Darwin": "libop_uniffi_core.dylib",
+        "Linux": "libop_uniffi_core.so",
+        "Windows": "op_uniffi_core.dll"
+    }
+    c_shared_library_file_name = platform_to_lib.get(platform.system(), "")
     c_shared_library_file_name = os.path.join(include_path, c_shared_library_file_name)
 
     uniffi_bindings_file_name = "op_uniffi_core.py"

--- a/src/onepassword/core.py
+++ b/src/onepassword/core.py
@@ -2,16 +2,14 @@ import json
 import platform
 
 
-if platform.machine().lower() == "x86_64" or platform.machine().lower() == "amd64":
+machine_arch = platform.machine().lower()
+
+if machine_arch in ["x86_64", "amd64"]:
     import onepassword.lib.x86_64.op_uniffi_core as core
-elif platform.machine().lower() == "aarch64" or platform.machine().lower() == "arm64":
+elif machine_arch in ["aarch64", "arm64"]:
     import onepassword.lib.aarch64.op_uniffi_core as core
 else:
-    raise ImportError(
-        "your machine's architecture is not currently supported: {}".format(
-            platform.machine()
-        )
-    )
+    raise ImportError(f"Your machine's architecture is not currently supported: {machine_arch}")
 
 
 # InitClient creates a client instance in the current core module and returns its unique ID.


### PR DESCRIPTION
This MR:
- Slightly refactors the code in `core.py` to enhance readability and simplify the logic for checking supported machine architectures
- Adds fix for deprecated ruff command in github workflow
- Slightly refactors and simplifies the code in `setup.py` for platform and machine type checks