### PR TITLE
Run integration tests on all target OS-es

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -22,7 +22,6 @@ jobs:
           python-version: '3.x'
           
       - name: Integration Test
-        if: github.repository_owner == '1Password' # don't run integration tests on forked PRs because those don't have access to pipeline secrets
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.TEST_SERVICE_ACCOUNT_TOKEN }}
         run: |

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -5,14 +5,14 @@ on:
   push:
     paths-ignore:
       - '**.md'
-  pull_request:
-    paths-ignore:
-      - '**.md'
 
 jobs:
 
   validate:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
 
@@ -21,14 +21,26 @@ jobs:
         with:
           python-version: '3.x'
           
-      - name: Test with pytest
+      - name: Integration Test
+        if: github.repository_owner == '1Password' # don't run integration tests on forked PRs because those don't have access to pipeline secrets
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.TEST_SERVICE_ACCOUNT_TOKEN }}
         run: |
           pip install pytest &&
           pip install pytest-asyncio &&
           pip install pydantic &&
-          python -m pytest src/onepassword/*.py
+          python -m pytest src/onepassword/test_client.py
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
 
       - name: Lint with Ruff
         run: |


### PR DESCRIPTION
## Summary

This PR modifies the Github actions so that the integration tests that require a valid service account token only run on internal PRs (not PRs that come from forks because those can't access repo secrets so they'll fail). We also modify the integration test to be run on all 3 supported OS-es 