### PR TITLE
Fix IDE errors around exposing items and secrets APIs

### DIFF
--- a/example/example.py
+++ b/example/example.py
@@ -1,6 +1,6 @@
 import asyncio
 import os
-from onepassword import Client, Item, ItemField, ItemSection
+from onepassword import *
 
 
 async def main():

--- a/example/example.py
+++ b/example/example.py
@@ -1,7 +1,6 @@
 import asyncio
 import os
-from onepassword.client import Client
-from onepassword.types import Item, ItemField, ItemSection
+from onepassword import Client, Item, ItemField, ItemSection
 
 
 async def main():

--- a/src/onepassword/__init__.py
+++ b/src/onepassword/__init__.py
@@ -3,7 +3,7 @@ from .client import Client
 from .defaults import DEFAULT_INTEGRATION_NAME, DEFAULT_INTEGRATION_VERSION
 from .secrets import Secrets
 from .items import Items
-from .types import *
+from .types import * # noqa F403
 
 
 __all__ = [

--- a/src/onepassword/__init__.py
+++ b/src/onepassword/__init__.py
@@ -14,4 +14,5 @@ __all__ = [
     "DEFAULT_INTEGRATION_VERSION",
 ]
 
-__all__ += types.__all__
+if hasattr(types, "__all__"):
+    __all__ += types.__all__

--- a/src/onepassword/__init__.py
+++ b/src/onepassword/__init__.py
@@ -1,9 +1,9 @@
 # AUTO-GENERATED
 from .client import Client
 from .defaults import DEFAULT_INTEGRATION_NAME, DEFAULT_INTEGRATION_VERSION
+from .types import * # noqa F403
 from .secrets import Secrets
 from .items import Items
-from .types import * # noqa F403
 
 
 __all__ = [

--- a/src/onepassword/__init__.py
+++ b/src/onepassword/__init__.py
@@ -1,3 +1,4 @@
+# AUTO-GENERATED
 from .client import Client
 from .defaults import DEFAULT_INTEGRATION_NAME, DEFAULT_INTEGRATION_VERSION
 from .secrets import Secrets

--- a/src/onepassword/__init__.py
+++ b/src/onepassword/__init__.py
@@ -2,12 +2,17 @@ from .client import Client
 from .defaults import DEFAULT_INTEGRATION_NAME, DEFAULT_INTEGRATION_VERSION
 from .secrets import Secrets
 from .items import Items
+from .types import Item, ItemField, ItemSection
+
 
 
 __all__ = [
     "Client",
     "Secrets",
     "Items",
+    "Item",
+    "ItemField",
+    "ItemSection",
     "DEFAULT_INTEGRATION_NAME",
     "DEFAULT_INTEGRATION_VERSION",
 ]

--- a/src/onepassword/__init__.py
+++ b/src/onepassword/__init__.py
@@ -2,17 +2,13 @@ from .client import Client
 from .defaults import DEFAULT_INTEGRATION_NAME, DEFAULT_INTEGRATION_VERSION
 from .secrets import Secrets
 from .items import Items
-from .types import Item, ItemField, ItemSection
-
+from .types import *
 
 
 __all__ = [
     "Client",
     "Secrets",
     "Items",
-    "Item",
-    "ItemField",
-    "ItemSection",
     "DEFAULT_INTEGRATION_NAME",
     "DEFAULT_INTEGRATION_VERSION",
 ]

--- a/src/onepassword/__init__.py
+++ b/src/onepassword/__init__.py
@@ -13,3 +13,5 @@ __all__ = [
     "DEFAULT_INTEGRATION_NAME",
     "DEFAULT_INTEGRATION_VERSION",
 ]
+
+__all__ += types.__all__

--- a/src/onepassword/client.py
+++ b/src/onepassword/client.py
@@ -7,22 +7,24 @@ from .items import Items
 
 
 class Client:
-    secrets: Secrets
-    items: Items
+	secrets: Secrets
+	items: Items
+	
 
-    @classmethod
-    async def authenticate(cls, auth, integration_name, integration_version):
-        config = new_default_config(
-            auth=auth,
-            integration_name=integration_name,
-            integration_version=integration_version,
+	@classmethod
+	async def authenticate(cls, auth, integration_name, integration_version):
+		config = new_default_config(
+			auth=auth,
+			integration_name=integration_name,
+			integration_version=integration_version,
         )
-        client_id = int(await _init_client(config))
+		client_id = int(await _init_client(config))
 
-        authenticated_client = cls()
+		authenticated_client = cls()
 
-        authenticated_client.secrets = Secrets(client_id)
-        authenticated_client.items = Items(client_id)
-        authenticated_client._finalizer = weakref.finalize(cls, _release_client, client_id)
+		authenticated_client.secrets = Secrets(client_id)
+		authenticated_client.items = Items(client_id)
+		authenticated_client._finalizer = weakref.finalize(cls, _release_client, client_id)
 
-        return authenticated_client
+		return authenticated_client
+	

--- a/src/onepassword/client.py
+++ b/src/onepassword/client.py
@@ -6,20 +6,23 @@ from .items import Items
 
 
 class Client:
-    def __init__(self, client_id):
-        self.secrets = Secrets(client_id)
-        self.items = Items(client_id)
+    secrets: Secrets
+    items: Items
 
     @classmethod
-    async def authenticate(cls, auth, integration_name, integration_version):
+    async def authenticate(self, auth, integration_name, integration_version):
         config = new_default_config(
             auth=auth,
             integration_name=integration_name,
             integration_version=integration_version,
         )
         client_id = int(await _init_client(config))
-        self = cls(client_id)
-        self._config = config
-        self._finalizer = weakref.finalize(self, _release_client, client_id)
 
-        return self
+        authenticated_client = self()
+
+        authenticated_client.secrets = Secrets(client_id)
+        authenticated_client.items = Items(client_id)
+        authenticated_client._config = config
+        authenticated_client._finalizer = weakref.finalize(self, _release_client, client_id)
+
+        return authenticated_client

--- a/src/onepassword/client.py
+++ b/src/onepassword/client.py
@@ -17,7 +17,7 @@ class Client:
 			auth=auth,
 			integration_name=integration_name,
 			integration_version=integration_version,
-        )
+		)
 		client_id = int(await _init_client(config))
 
 		authenticated_client = cls()
@@ -27,4 +27,3 @@ class Client:
 		authenticated_client._finalizer = weakref.finalize(cls, _release_client, client_id)
 
 		return authenticated_client
-	

--- a/src/onepassword/client.py
+++ b/src/onepassword/client.py
@@ -1,3 +1,4 @@
+# AUTO-GENERATED
 import weakref
 from .core import _init_client, _release_client
 from .defaults import new_default_config

--- a/src/onepassword/client.py
+++ b/src/onepassword/client.py
@@ -6,19 +6,20 @@ from .items import Items
 
 
 class Client:
+    def __init__(self, client_id):
+        self.secrets = Secrets(client_id)
+        self.items = Items(client_id)
+
     @classmethod
     async def authenticate(cls, auth, integration_name, integration_version):
-        self = cls()
-
-        self.config = new_default_config(
+        config = new_default_config(
             auth=auth,
             integration_name=integration_name,
             integration_version=integration_version,
         )
-        client_id = int(await _init_client(self.config))
-
-        self.secrets = Secrets(client_id)
-        self.items = Items(client_id)
+        client_id = int(await _init_client(config))
+        self = cls(client_id)
+        self._config = config
         self._finalizer = weakref.finalize(self, _release_client, client_id)
 
         return self

--- a/src/onepassword/client.py
+++ b/src/onepassword/client.py
@@ -22,7 +22,6 @@ class Client:
 
         authenticated_client.secrets = Secrets(client_id)
         authenticated_client.items = Items(client_id)
-        authenticated_client._config = config
         authenticated_client._finalizer = weakref.finalize(self, _release_client, client_id)
 
         return authenticated_client

--- a/src/onepassword/client.py
+++ b/src/onepassword/client.py
@@ -11,7 +11,7 @@ class Client:
     items: Items
 
     @classmethod
-    async def authenticate(self, auth, integration_name, integration_version):
+    async def authenticate(cls, auth, integration_name, integration_version):
         config = new_default_config(
             auth=auth,
             integration_name=integration_name,
@@ -19,10 +19,10 @@ class Client:
         )
         client_id = int(await _init_client(config))
 
-        authenticated_client = self()
+        authenticated_client = cls()
 
         authenticated_client.secrets = Secrets(client_id)
         authenticated_client.items = Items(client_id)
-        authenticated_client._finalizer = weakref.finalize(self, _release_client, client_id)
+        authenticated_client._finalizer = weakref.finalize(cls, _release_client, client_id)
 
         return authenticated_client

--- a/src/onepassword/test_client.py
+++ b/src/onepassword/test_client.py
@@ -49,13 +49,13 @@ async def test_good_client_construction():
         integration_name=onepassword_defaults.DEFAULT_INTEGRATION_NAME,
         integration_version=onepassword_defaults.DEFAULT_INTEGRATION_VERSION,
     )
-    assert client.config["serviceAccountToken"] == TOKEN
+    assert client._config["serviceAccountToken"] == TOKEN
     assert (
-        client.config["integrationName"]
+        client._config["integrationName"]
         == onepassword_defaults.DEFAULT_INTEGRATION_NAME
     )
     assert (
-        client.config["integrationVersion"]
+        client._config["integrationVersion"]
         == onepassword_defaults.DEFAULT_INTEGRATION_VERSION
     )
 

--- a/src/onepassword/test_client.py
+++ b/src/onepassword/test_client.py
@@ -40,26 +40,6 @@ async def test_invalid_resolve():
 
 ## test client constructor
 
-
-# valid
-@pytest.mark.asyncio
-async def test_good_client_construction():
-    client = await onepassword.Client.authenticate(
-        auth=TOKEN,
-        integration_name=onepassword_defaults.DEFAULT_INTEGRATION_NAME,
-        integration_version=onepassword_defaults.DEFAULT_INTEGRATION_VERSION,
-    )
-    assert client._config["serviceAccountToken"] == TOKEN
-    assert (
-        client._config["integrationName"]
-        == onepassword_defaults.DEFAULT_INTEGRATION_NAME
-    )
-    assert (
-        client._config["integrationVersion"]
-        == onepassword_defaults.DEFAULT_INTEGRATION_VERSION
-    )
-
-
 # invalid
 @pytest.mark.asyncio
 async def test_client_construction_no_auth():


### PR DESCRIPTION
## Summary

Currently, the way that the generated Python SDK implements the various functions it supports results in IDE errors (red squiggly lines) in most modern IDEs. The functions are also not autocompleted correctly.


To offer a good developer experience for anyone using the Python SDK, we should structure the Python SDK in a way that is compatible with how most Python IDEs / IDE plugins work, such that the SDK function calls don't get classified as errors/warnings and the namespace and function names get autocompleted.

## Thought process
The first attempt was to add an `__init__`  function for exposing the items and secrets APIs as public fields. (see the first commit)

However, the init function could give the false impression that a Client should be initialised via the classical constructor. That isn't how our client is supposed to work because we're performing asynchronous tasks upon initialization, and the magic init function doesn't have support for async operations. Therefore the expectation should remain that only the `authenticate` method must be used to start up a client.

I switched to using the [typing feature](https://docs.python.org/3/library/typing.html) of Python 3.6 for making the secrets and items transparent to the IDE.

## How to test

Install the current's branch version: `pip install .`

In the `examples/examples.py` file play around with the sdk and see that the fields and their methods are now discoverable through the IDE.