### PR TITLE
Update README to simplify service account creation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ Before you get started, [create a service account](https://developer.1password.c
 
 ## ❗ Limitations
 
-1Password SDKs currently only support operations on text and concealed fields. If you update or delete an item that has information saved in other field types, that information will be permanently lost.
-
 1Password SDKs don't yet support using secret references with query parameters, so you can't retrieve file attachments or SSH keys, or get more information about field metadata.
+
+1Password SDKs currently only support operations on text and concealed fields. As a result, you can't edit items that include information saved in other types of fields.
 
 When managing items with 1Password SDKs, you must use [unique identifiers (IDs)](https://developer.1password.com/docs/sdks/concepts#unique-identifiers) in place of vault, item, and field names.
 

--- a/README.md
+++ b/README.md
@@ -16,11 +16,8 @@
 
 The 1Password Python SDK offers programmatic access to your secrets in 1Password with Python. During the beta, you can create, retrieve, update, and delete items and resolve secret references.
 
-## 🔑 Authentication
+1Password SDKs support authentication with [1Password Service Accounts](https://developer.1password.com/docs/service-accounts/get-started/).
 
-1Password SDKs support authentication with [1Password Service Accounts](https://developer.1password.com/docs/service-accounts/get-started/). You can create service accounts if you're an owner or administrator on your team. Otherwise, ask your administrator for a service account token.
-
-Before you get started, [create a service account](https://developer.1password.com/docs/service-accounts/get-started/#create-a-service-account) and give it the appropriate permissions in the vaults where the items you want to use with the SDK are saved.
 
 ## ❗ Limitations
 
@@ -34,7 +31,8 @@ When managing items with 1Password SDKs, you must use [unique identifiers (IDs)]
 
 To use the 1Password Python SDK in your project:
 
-1. Provision your [service account](#authentication) token. We recommend provisioning your token from the environment. For example, to export your token to the `OP_SERVICE_ACCOUNT_TOKEN` environment variable:
+1. [Create a service account](https://my.1password.com/developer-tools/infrastructure-secrets/serviceaccount/) and give it the appropriate permissions in the vaults where the items you want to use with the SDK are saved.
+2. Provision your service account token. We recommend provisioning your token from the environment. For example, to export your token to the `OP_SERVICE_ACCOUNT_TOKEN` environment variable:
 
    **macOS or Linux**
 
@@ -48,13 +46,13 @@ To use the 1Password Python SDK in your project:
    $Env:OP_SERVICE_ACCOUNT_TOKEN = "<your-service-account-token>"
    ```
 
-2. Install the 1Password Python SDK in your project:
+3. Install the 1Password Python SDK in your project:
 
    ```bash
    pip install git+ssh://git@github.com/1Password/onepassword-sdk-python.git@v0.1.0-beta.5
    ```
 
-3. Use the Python SDK in your project:
+4. Use the Python SDK in your project:
 
 ```python
 import asyncio


### PR DESCRIPTION
This MR updates the README to directly link to the 1password.com page where you can create a service account. It also simplifies the service account information by moving this instruction into the get started section and removing the authentication section.

Relates to this issue: https://gitlab.1password.io/dev/sdk/sdk-core/-/issues/141#note_3220318