### PR TITLE
Improve Example Code to Correctly Error Out when OP_SERVICE_ACCOUNT_TOKEN is not set.

### DIFF
--- a/example/example.py
+++ b/example/example.py
@@ -4,8 +4,8 @@ from onepassword import *
 
 
 async def main():
-    # Gets your service account token from the OP_SERVICE_ACCOUNT_TOKEN environment variable.
-    token = os.getenv("OP_SERVICE_ACCOUNT_TOKEN")
+    # Gets your service account token from the OP_SERVICE_ACCOUNT_TOKEN environment variable and sets it to empty string if not set.
+    token = os.getenv("OP_SERVICE_ACCOUNT_TOKEN") or ""
 
     # Connects to 1Password.
     client = await Client.authenticate(


### PR DESCRIPTION
This MR will update `example.py` to show the correct error message when `OP_SERVICE_ACCOUNT_TOKEN` is empty.

Before it would show this error:
`onepassword.lib.aarch64.op_uniffi_core.Error.Error: msg='invalid type: null, expected a string at line 1 column 28'`

This was due to `os.getenv` setting the value of token to None when its empty instead of setting it as an empty string.

Updated the code to ensure that if the `OP_SERVICE_ACCOUNT_TOKEN` is empty than assign it as an empty string.