### PR TITLE
Clarify Item field details optionality

### DIFF
--- a/src/onepassword/types.py
+++ b/src/onepassword/types.py
@@ -123,9 +123,9 @@ class ItemField(BaseModel):
     """
     The string representation of the field's value
     """
-    details: Optional[ItemFieldDetails]
+    details: [ItemFieldDetails]
     """
-    Field type-specific attributes.
+    Field type-specific attributes. Must be set to None.
     """
 
 


### PR DESCRIPTION
This PR removes the "optional" note from item field details, and clarifies that this field should currently be set to None.