### PR TITLE
Switch recommended installation method to leveraging git via HTTP

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ To use the 1Password Python SDK in your project:
 3. Install the 1Password Python SDK in your project:
 
    ```bash
-   pip install git+ssh://git@github.com/1Password/onepassword-sdk-python.git@v0.1.1
+   pip install git+https://git@github.com/1Password/onepassword-sdk-python.git@v0.1.1
    ```
 
 4. Use the Python SDK in your project:


### PR DESCRIPTION
The currently recommended installation method (via SSH) only works if the user has an SSH key configured.

This is likely not the case in all environments, such as Docker containers, so we should switch to an installation method that does not make any assumption's about the user's setup.