### PR TITLE
Publish the 1Password SDK for Python on PyPI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist/
 onepassword.egg-info/
 .DS_Store
 build/
+.python-version

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,9 @@ prep-release:
 release/install-dependencies:
 # Install pyenv
 	brew install pyenv
+
+# Install build
+	pip3 install build
 	
 # Install all the python versions we support in one line
 	pyenv install --skip-existing $(PYTHON_VERSIONS)

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,9 @@ prep-release:
 	src/release/scripts/prep-release.sh
 
 release/install-dependencies:
+# Install pyenv
+	brew install pyenv
+	
 # Install all the python versions we support in one line
 	pyenv install --skip-existing $(PYTHON_VERSIONS)
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,17 @@
+PYTHON_VERSIONS := 3.9 3.10 3.11 3.12
+
 release:
-	src/release/scripts/release.sh
+	src/release/scripts/release.sh $(PYTHON_VERSIONS)
 
 prep-release:
 	src/release/scripts/prep-release.sh
 
+release/install-dependencies:
+# Install all the python versions we support in one line
+	pyenv install --skip-existing $(PYTHON_VERSIONS)
 
+# Set pyenv local and install dependencies for each version
+	for version in $(PYTHON_VERSIONS); do \
+		pyenv local $$version; \
+		pyenv exec pip install wheel setuptools; \
+	done

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ release/install-dependencies:
 	brew install pyenv
 
 # Install build
-	pip3 install build
+	pip install build --break-system-packages
 	
 # Install all the python versions we support in one line
 	pyenv install --skip-existing $(PYTHON_VERSIONS)

--- a/setup.py
+++ b/setup.py
@@ -55,9 +55,15 @@ setup(
     packages=find_packages(
         where="src",
     ),
+    license="MIT",
+    license_files="LICENSE",
     package_dir={"": "src"},
     python_requires=">=3.9",
     classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Operating System :: MacOS",
+    "Operating System :: POSIX :: Linux",
+    "Operating System :: Microsoft :: Windows",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ def get_shared_library_data_to_include():
 
 
 setup(
-    name="onepassword_sdk",
+    name="onepassword-sdk",
     version="0.1.1",
     author="1Password",
     long_description= (Path(__file__).parent / "README.md").read_text(),

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ except ImportError:
 def get_shared_library_data_to_include():
     # Return the correct uniffi C shared library extension for the given platform
     include_path = "lib"
-    machine_type = platform.machine().lower()
+    machine_type = os.getenv("PYTHON_MACHINE_PLATFORM") or platform.machine().lower() 
     if machine_type in ["x86_64", "amd64"]:
         include_path = os.path.join(include_path, "x86_64")
     elif machine_type in ["aarch64", "arm64"]:
@@ -32,7 +32,8 @@ def get_shared_library_data_to_include():
         "Linux": "libop_uniffi_core.so",
         "Windows": "op_uniffi_core.dll",
     }
-    c_shared_library_file_name = platform_to_lib.get(platform.system(), "")
+    platform_name = os.getenv("PYTHON_OS_PLATFORM") or platform.system()
+    c_shared_library_file_name = platform_to_lib.get(platform_name, "")
     c_shared_library_file_name = os.path.join(include_path, c_shared_library_file_name)
 
     uniffi_bindings_file_name = "op_uniffi_core.py"
@@ -42,7 +43,7 @@ def get_shared_library_data_to_include():
 
 
 setup(
-    name="onepassword",
+    name="onepassword_sdk",
     version="0.1.1",
     author="1Password",
     description="The 1Password Python SDK offers programmatic read access to your secrets in 1Password in an interface native to Python.",
@@ -51,9 +52,12 @@ setup(
         where="src",
     ),
     package_dir={"": "src"},
+    python_requires=">=3.8",
     cmdclass={"bdist_wheel": bdist_wheel},
     package_data={"": get_shared_library_data_to_include()},
     install_requires=[
         "pydantic",
+        'pip>=20.3',
+        'auditwheel>=3.3'
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -68,6 +68,6 @@ setup(
     cmdclass={"bdist_wheel": bdist_wheel},
     package_data={"": get_shared_library_data_to_include()},
     install_requires=[
-        "pydantic",
+        "pydantic>=2.5", # Minimum Pydantic version to run the Python SDK
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from setuptools import setup, find_packages
 from sysconfig import get_platform
 import platform
@@ -46,6 +47,8 @@ setup(
     name="onepassword_sdk",
     version="0.1.1",
     author="1Password",
+    long_description= (Path(__file__).parent / "README.md").read_text(),
+    long_description_content_type='text/markdown',
     description="The 1Password Python SDK offers programmatic read access to your secrets in 1Password in an interface native to Python.",
     url="https://github.com/1Password/onepassword-sdk-python",
     packages=find_packages(
@@ -53,11 +56,17 @@ setup(
     ),
     package_dir={"": "src"},
     python_requires=">=3.8",
+    classifiers = [
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "License :: OSI Approved :: MIT License"
+    ],
     cmdclass={"bdist_wheel": bdist_wheel},
     package_data={"": get_shared_library_data_to_include()},
     install_requires=[
         "pydantic",
-        'pip>=20.3',
-        'auditwheel>=3.3'
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ try:
             # This platform naming is sufficient for distributing this package via source cloning (e.g. pip + GitHub) since the wheel will be built locally
             # for each user's platform: https://packaging.python.org/en/latest/specifications/platform-compatibility-tags/#basic-platform-tags
             self.plat_name = get_platform().translate({"-": "_", ".": "_"})
+            self.plat_name_supplied = True
 except ImportError:
     bdist_wheel = None
 

--- a/setup.py
+++ b/setup.py
@@ -56,9 +56,8 @@ setup(
         where="src",
     ),
     package_dir={"": "src"},
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     classifiers = [
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",

--- a/src/release/README.md
+++ b/src/release/README.md
@@ -1,6 +1,19 @@
 ## How to Prepare a Release for the Python SDK
 
-Before running this script, the user must make sure that they have the write permissions to the Python SDK repository.
+Before running this script, the user must make sure that they have the write permissions to the Python SDK repository and you have pyenv installed: You can do so by doing the following if your on macOS:
+
+```
+brew install pyenv
+```
+
+The following versions and packages must be installed for each Python Version to use pyenv:
+```
+Python 3.8 + wheels (pyenv install 3.8) + (pyenv exec pip install wheels)
+Python 3.9 + wheels (pyenv install 3.9) + (pyenv exec pip install wheels)
+Python 3.10 + wheels (pyenv install 3.10) + (pyenv exec pip install wheels)
+Python 3.11 + wheels (pyenv install 3.11) + (pyenv exec pip install wheels)
+Python 3.12 + wheels + setuptools (pyenv install 3.12) + (pyenv exec pip install wheels setuptools)
+```
 
 Step 1. Make any changes to the SDK as required on a feature branch or main branch.
 NOTE: If ran on a main branch, a release branch will be created.
@@ -15,8 +28,10 @@ Step 3. Ensure that the correct files have been updated - i.e. version/build fil
 
 Step 4. Ensure your GITHUB_TOKEN environment variable is set as this will allow you to create the tags/release and push it.
 
-Step 5. If everything looks good, at the root of the repo, run:
+Step 6. Ensure you have the PyPi credentials to login when uploading the source and wheels to PyPi.
+
+Step 7. If everything looks good, at the root of the repo, run:
 ```
 make release
 ```
-Step 6. Congratulations, you have released the newest Python SDK!
+Step 8. Congratulations, you have released the newest Python SDK!

--- a/src/release/README.md
+++ b/src/release/README.md
@@ -6,13 +6,9 @@ Before running this script, the user must make sure that they have the write per
 brew install pyenv
 ```
 
-The following versions and packages must be installed for each Python Version to use pyenv:
+Run this make command to install all dependencies required for pyenv:
 ```
-Python 3.8 + wheels (pyenv install 3.8) + (pyenv exec pip install wheels)
-Python 3.9 + wheels (pyenv install 3.9) + (pyenv exec pip install wheels)
-Python 3.10 + wheels (pyenv install 3.10) + (pyenv exec pip install wheels)
-Python 3.11 + wheels (pyenv install 3.11) + (pyenv exec pip install wheels)
-Python 3.12 + wheels + setuptools (pyenv install 3.12) + (pyenv exec pip install wheels setuptools)
+release/install-dependencies
 ```
 
 Step 1. Make any changes to the SDK as required on a feature branch or main branch.

--- a/src/release/README.md
+++ b/src/release/README.md
@@ -1,12 +1,8 @@
 ## How to Prepare a Release for the Python SDK
 
-Before running this script, the user must make sure that they have the write permissions to the Python SDK repository and you have pyenv installed: You can do so by doing the following if your on macOS:
+Before running this script, the user must make sure that they have the write permissions to the Python SDK repository.
 
-```
-brew install pyenv
-```
-
-Run this make command to install all dependencies required for pyenv:
+Run this make command to install all dependencies required for the Python SDK release process.
 ```
 release/install-dependencies
 ```

--- a/src/release/scripts/prep-release.sh
+++ b/src/release/scripts/prep-release.sh
@@ -73,46 +73,6 @@ update_and_validate_build() {
     done
 }
 
-
-acquire_wheels_pypi() {
-    # Acquire wheels for MacOS for 64 Bit Intel/AMD (x86_64)
-    export PYTHON_OS_PLATFORM="Darwin"
-    export PYTHON_MACHINE_PLATFORM="x86_64"
-    export _PYTHON_HOST_PLATFORM="macosx-14.0-${PYTHON_MACHINE_PLATFORM}"
-    python3 -m build --wheel
-    rm -rf build 
-
-    # Acquire wheels for MacOS for 64 Bit ARM (arm64)
-    export PYTHON_MACHINE_PLATFORM="arm64"
-    export _PYTHON_HOST_PLATFORM="macosx-14.0-${PYTHON_MACHINE_PLATFORM}"
-    python3 -m build --wheel
-    rm -rf build 
-
-    # Acquire wheels for Linux for 64 Bit ARM
-    export PYTHON_OS_PLATFORM="Linux"
-    export PYTHON_MACHINE_PLATFORM="aarch64"
-    export _PYTHON_HOST_PLATFORM="manylinux-2-32-${PYTHON_MACHINE_PLATFORM}"
-    python3 -m build --wheel
-    rm -rf build
-
-    # Acquire wheels for Linux for 64 Bit Intel/AMD
-    export PYTHON_MACHINE_PLATFORM="x86_64"
-    export _PYTHON_HOST_PLATFORM="manylinux-2-32-${PYTHON_MACHINE_PLATFORM}"
-    python3 -m build --wheel
-    rm -rf build
-
-    # Acquire wheels for Windows for 64 Bit Intel/AMD (x86_64)
-    export PYTHON_OS_PLATFORM="Windows"
-    export PYTHON_MACHINE_PLATFORM="amd64"
-    export _PYTHON_HOST_PLATFORM="win-${PYTHON_MACHINE_PLATFORM}"
-    python3 -m build --wheel
-    rm -rf build
-
-    # TEST
-    python3 -m twine upload --repository-url https://test.pypi.org/legacy/ dist/* 
-
-}
-
 # Ensure working directory is clean
 enforce_latest_code
 
@@ -121,9 +81,6 @@ update_and_validate_version
 
 # Update and validate the build number
 update_and_validate_build 
-
-# Acquire wheels for different distro for PyPi
-acquire_wheels_pypi
 
 # Update version & build number in version.py
 sed -e "s/{{ build }}/$build/" -e "s/{{ version }}/$version/" "$version_template_file" > "$output_version_file"

--- a/src/release/scripts/prep-release.sh
+++ b/src/release/scripts/prep-release.sh
@@ -109,15 +109,12 @@ acquire_wheels_pypi() {
     rm -rf build
 
     # TEST
-    python3 -m twine upload --repository-url https://test.pypi.org/legacy/ dist/* --verbose
+    python3 -m twine upload --repository-url https://test.pypi.org/legacy/ dist/* 
 
 }
 
-# Acquire wheels for different distro for PyPi
-acquire_wheels_pypi
-
 # Ensure working directory is clean
-# enforce_latest_code
+enforce_latest_code
 
 # Update and validate the version number
 update_and_validate_version
@@ -125,8 +122,8 @@ update_and_validate_version
 # Update and validate the build number
 update_and_validate_build 
 
-# # Acquire wheels for different distro for PyPi
-# acquire_wheels_pypi
+# Acquire wheels for different distro for PyPi
+acquire_wheels_pypi
 
 # Update version & build number in version.py
 sed -e "s/{{ build }}/$build/" -e "s/{{ version }}/$version/" "$version_template_file" > "$output_version_file"

--- a/src/release/scripts/prep-release.sh
+++ b/src/release/scripts/prep-release.sh
@@ -73,14 +73,60 @@ update_and_validate_build() {
     done
 }
 
+
+acquire_wheels_pypi() {
+    # Acquire wheels for MacOS for 64 Bit Intel/AMD (x86_64)
+    export PYTHON_OS_PLATFORM="Darwin"
+    export PYTHON_MACHINE_PLATFORM="x86_64"
+    export _PYTHON_HOST_PLATFORM="macosx-14.0-${PYTHON_MACHINE_PLATFORM}"
+    python3 -m build --wheel
+    rm -rf build 
+
+    # Acquire wheels for MacOS for 64 Bit ARM (arm64)
+    export PYTHON_MACHINE_PLATFORM="arm64"
+    export _PYTHON_HOST_PLATFORM="macosx-14.0-${PYTHON_MACHINE_PLATFORM}"
+    python3 -m build --wheel
+    rm -rf build 
+
+    # Acquire wheels for Linux for 64 Bit ARM
+    export PYTHON_OS_PLATFORM="Linux"
+    export PYTHON_MACHINE_PLATFORM="aarch64"
+    export _PYTHON_HOST_PLATFORM="manylinux-2-32-${PYTHON_MACHINE_PLATFORM}"
+    python3 -m build --wheel
+    rm -rf build
+
+    # Acquire wheels for Linux for 64 Bit Intel/AMD
+    export PYTHON_MACHINE_PLATFORM="x86_64"
+    export _PYTHON_HOST_PLATFORM="manylinux-2-32-${PYTHON_MACHINE_PLATFORM}"
+    python3 -m build --wheel
+    rm -rf build
+
+    # Acquire wheels for Windows for 64 Bit Intel/AMD (x86_64)
+    export PYTHON_OS_PLATFORM="Windows"
+    export PYTHON_MACHINE_PLATFORM="amd64"
+    export _PYTHON_HOST_PLATFORM="win-${PYTHON_MACHINE_PLATFORM}"
+    python3 -m build --wheel
+    rm -rf build
+
+    # TEST
+    python3 -m twine upload --repository-url https://test.pypi.org/legacy/ dist/* --verbose
+
+}
+
+# Acquire wheels for different distro for PyPi
+acquire_wheels_pypi
+
 # Ensure working directory is clean
-enforce_latest_code
+# enforce_latest_code
 
 # Update and validate the version number
 update_and_validate_version
 
 # Update and validate the build number
 update_and_validate_build 
+
+# # Acquire wheels for different distro for PyPi
+# acquire_wheels_pypi
 
 # Update version & build number in version.py
 sed -e "s/{{ build }}/$build/" -e "s/{{ version }}/$version/" "$version_template_file" > "$output_version_file"

--- a/src/release/scripts/release.sh
+++ b/src/release/scripts/release.sh
@@ -68,7 +68,6 @@ git push origin tag "v${sdk_version}"
 
 gh release create "v${sdk_version}" --title "Release ${sdk_version}" --notes "${release_notes}" --repo github.com/1Password/onepassword-sdk-python
 
-
 # Acquire the wheels for different OS
 build_wheels Darwin x86_64
 build_wheels Darwin arm64
@@ -84,3 +83,4 @@ python3 -m twine upload --repository testpypi dist/* --verbose
 
 # Delete the dist folder after published
 rm -r dist src/*.egg-info
+

--- a/src/release/scripts/release.sh
+++ b/src/release/scripts/release.sh
@@ -4,6 +4,52 @@
 
 set -e
 
+# Minimum glibc version we support
+glibc_version=2-32
+
+# These versions are being supported due to the SDKs supporting Python 3.8+
+macOS_version_x86_64=10.9
+macOS_version_arm64=11.0
+
+acquire_wheels() {
+    os_platform=$1
+    machine_platform=$2
+    version=
+
+    case "$os_platform" in
+        Darwin)
+            if [[ "$machine_platform" == "x86_64" ]]; then
+                version=$min_macOS_version_x86_64
+                export MACOSX_DEPLOYMENT_TARGET=$macOS_version_x86_64
+            else
+                version=$min_macOS_version_arm64
+                export MACOSX_DEPLOYMENT_TARGET=$macOS_version_arm64
+
+            fi
+            export PYTHON_OS_PLATFORM=$os_platform
+            export PYTHON_MACHINE_PLATFORM=$machine_platform
+            export _PYTHON_HOST_PLATFORM="macosx-${version}-${PYTHON_MACHINE_PLATFORM}"
+            ;;
+        Linux)
+            export PYTHON_OS_PLATFORM=$os_platform
+            export PYTHON_MACHINE_PLATFORM=$machine_platform
+            export _PYTHON_HOST_PLATFORM="manylinux-${glibc_version}-${PYTHON_MACHINE_PLATFORM}"
+            ;;
+        Windows)
+            export PYTHON_OS_PLATFORM=$os_platform
+            export PYTHON_MACHINE_PLATFORM=$machine_platform
+            export _PYTHON_HOST_PLATFORM="win-${PYTHON_MACHINE_PLATFORM}"
+            ;;
+        *)
+            echo "Unsupported OS: $os_platform"
+            exit 1
+            ;;
+    esac
+
+    python3 -m build --wheel
+    rm -rf build
+}
+
 # Read the contents of the files into variables
 version=$(awk -F "['\"]" '/SDK_VERSION =/{print $2}' "src/release/version.py")
 build=$(awk -F "['\"]" '/SDK_BUILD_NUMBER =/{print $2}' "src/release/version.py")
@@ -29,3 +75,13 @@ git push origin tag "v${version}"
 
 gh release create "v${version}" --title "Release ${version}" --notes "${release_notes}" --repo github.com/1Password/onepassword-sdk-python
 
+
+# Acquire the wheels for different OS
+acquire_wheels Darwin x86_64
+acquire_wheels Darwin arm64
+acquire_wheels Linux x86_64
+acquire_wheels Linux aarch64
+acquire_wheels Windows amd64
+
+# Release on PyPi
+python3 -m twine upload --repository testpypi dist/* --verbose

--- a/src/release/scripts/release.sh
+++ b/src/release/scripts/release.sh
@@ -4,7 +4,7 @@
 
 set -e
 
-intel_amd_tag=x86_64
+intel_tag=x86_64
 arm_tag=arm64
 
 # Minimum glibc version we support
@@ -17,14 +17,14 @@ macOS_version_arm64=11.0
 build_wheels() {
     os_platform=$1
     machine_platform=$2
-    version=
 
     export PYTHON_OS_PLATFORM=$os_platform
     export PYTHON_MACHINE_PLATFORM=$machine_platform
 
     case "$os_platform" in 
         Darwin)
-            if [[ "$machine_platform" == "$intel_amd_tag" ]]; then
+            version=
+            if [[ "$machine_platform" == "$intel_tag" ]]; then
                 version=$macOS_version_x86_64
                 export MACOSX_DEPLOYMENT_TARGET=$macOS_version_x86_64
             else
@@ -67,18 +67,18 @@ if [ -z "${GITHUB_TOKEN}" ]; then
   exit 1
 fi
 
-git tag -a -s  "v${version}" -m "${version}"
+git tag -a -s  "v${sdk_version}" -m "${sdk_version}"
 
 # Push the tag to the branch
-git push origin tag "v${version}"
+git push origin tag "v${sdk_version}"
 
-gh release create "v${version}" --title "Release ${version}" --notes "${release_notes}" --repo github.com/1Password/onepassword-sdk-python
+gh release create "v${sdk_version}" --title "Release ${sdk_version}" --notes "${release_notes}" --repo github.com/1Password/onepassword-sdk-python
 
 
 # Acquire the wheels for different OS
-build_wheels Darwin $intel_amd_tag
+build_wheels Darwin $intel_tag
 build_wheels Darwin $arm_tag
-build_wheels Linux $intel_amd_tag
+build_wheels Linux $intel_tag
 build_wheels Linux aarch64
 build_wheels Windows amd64
 
@@ -87,10 +87,10 @@ python3 -m build --sdist
 
 # Retag these as MacOS 11.0 and 10.9 as they are built for it but the platform tag does not get renamed as grabs your computers version regardless of whats set
 python3 -m wheel tags --platform-tag macosx_11_0_$arm_tag dist/onepassword_sdk-$sdk_version-cp312-cp312-macosx_14_0_$arm_tag.whl
-python3 -m wheel tags --platform-tag macosx_10_9_$intel_amd_tag dist/onepassword_sdk-$sdk_version-cp312-cp312-macosx_14_0_$intel_amd_tag.whl
+python3 -m wheel tags --platform-tag macosx_10_9_$intel_tag dist/onepassword_sdk-$sdk_version-cp312-cp312-macosx_14_0_$intel_tag.whl
 
 # Remove the old wheels
-rm dist/onepassword_sdk-$sdk_version-cp312-cp312-macosx_14_0_$intel_amd_tag.whl
+rm dist/onepassword_sdk-$sdk_version-cp312-cp312-macosx_14_0_$intel_tag.whl
 rm dist/onepassword_sdk-$sdk_version-cp312-cp312-macosx_14_0_$arm_tag.whl
 
 # Release on PyPi

--- a/src/release/scripts/release.sh
+++ b/src/release/scripts/release.sh
@@ -79,7 +79,7 @@ build_wheels Windows amd64
 python3 -m build --sdist
 
 # Release on PyPi
-python3 -m twine upload --repository testpypi dist/* --verbose
+python3 -m twine upload --repository testpypi dist/*
 
 # Delete the dist folder after published
 rm -r dist src/*.egg-info

--- a/src/release/scripts/release.sh
+++ b/src/release/scripts/release.sh
@@ -45,7 +45,7 @@ build_wheels() {
 }
 
 # Read the contents of the files into variables
-sdk_version=$(awk -F "['\"]" '/SDK_VERSION =/{print $2}' "src/release/version.py")
+version=$(awk -F "['\"]" '/SDK_VERSION =/{print $2}' "src/release/version.py")
 build=$(awk -F "['\"]" '/SDK_BUILD_NUMBER =/{print $2}' "src/release/version.py")
 release_notes=$(< src/release/RELEASE-NOTES)
 
@@ -61,12 +61,12 @@ if [ -z "${GITHUB_TOKEN}" ]; then
   exit 1
 fi
 
-git tag -a -s  "v${sdk_version}" -m "${sdk_version}"
+git tag -a -s  "v${version}" -m "${version}"
 
 # Push the tag to the branch
-git push origin tag "v${sdk_version}"
+git push origin tag "v${version}"
 
-gh release create "v${sdk_version}" --title "Release ${sdk_version}" --notes "${release_notes}" --repo github.com/1Password/onepassword-sdk-python
+gh release create "v${version}" --title "Release ${version}" --notes "${release_notes}" --repo github.com/1Password/onepassword-sdk-python
 
 # Acquire the wheels for different OS
 build_wheels Darwin x86_64

--- a/src/release/scripts/release.sh
+++ b/src/release/scripts/release.sh
@@ -11,10 +11,13 @@ glibc_version=2-32
 macOS_version_x86_64=10.9
 macOS_version_arm64=11.0
 
-acquire_wheels() {
+build_wheels() {
     os_platform=$1
     machine_platform=$2
     version=
+
+    export PYTHON_OS_PLATFORM=$os_platform
+    export PYTHON_MACHINE_PLATFORM=$machine_platform
 
     case "$os_platform" in
         Darwin)
@@ -26,18 +29,12 @@ acquire_wheels() {
                 export MACOSX_DEPLOYMENT_TARGET=$macOS_version_arm64
 
             fi
-            export PYTHON_OS_PLATFORM=$os_platform
-            export PYTHON_MACHINE_PLATFORM=$machine_platform
             export _PYTHON_HOST_PLATFORM="macosx-${version}-${PYTHON_MACHINE_PLATFORM}"
             ;;
         Linux)
-            export PYTHON_OS_PLATFORM=$os_platform
-            export PYTHON_MACHINE_PLATFORM=$machine_platform
             export _PYTHON_HOST_PLATFORM="manylinux-${glibc_version}-${PYTHON_MACHINE_PLATFORM}"
             ;;
         Windows)
-            export PYTHON_OS_PLATFORM=$os_platform
-            export PYTHON_MACHINE_PLATFORM=$machine_platform
             export _PYTHON_HOST_PLATFORM="win-${PYTHON_MACHINE_PLATFORM}"
             ;;
         *)
@@ -77,11 +74,11 @@ gh release create "v${version}" --title "Release ${version}" --notes "${release_
 
 
 # Acquire the wheels for different OS
-acquire_wheels Darwin x86_64
-acquire_wheels Darwin arm64
-acquire_wheels Linux x86_64
-acquire_wheels Linux aarch64
-acquire_wheels Windows amd64
+build_wheels Darwin x86_64
+build_wheels Darwin arm64
+build_wheels Linux x86_64
+build_wheels Linux aarch64
+build_wheels Windows amd64
 
 # Release on PyPi
 python3 -m twine upload --repository testpypi dist/* --verbose

--- a/src/release/scripts/release.sh
+++ b/src/release/scripts/release.sh
@@ -3,6 +3,10 @@
 # Helper script to release the Python SDK
 
 set -e
+
+# The list of python verisons the SDKs release for
+python_versions=("3.8" "3.9" "3.10" "3.11" "3.12")
+
 # Minimum glibc version we support
 glibc_version=2-32
 
@@ -40,7 +44,7 @@ build_wheels() {
             ;;
     esac
 
-    python3 -m build --wheel
+    pyenv exec python setup.py bdist_wheel
     rm -rf build
 }
 
@@ -68,12 +72,16 @@ git push origin tag "v${version}"
 
 gh release create "v${version}" --title "Release ${version}" --notes "${release_notes}" --repo github.com/1Password/onepassword-sdk-python
 
+
 # Acquire the wheels for different OS
+for version in "${python_versions[@]}"; do
+pyenv global $version
 build_wheels Darwin x86_64
 build_wheels Darwin arm64
 build_wheels Linux x86_64
 build_wheels Linux aarch64
 build_wheels Windows amd64
+done
 
 # Build Source as well incase wheels fails, pypi can install this as backup (standard practice)
 python3 -m build --sdist

--- a/src/release/scripts/release.sh
+++ b/src/release/scripts/release.sh
@@ -5,12 +5,12 @@
 set -e
 
 # The list of python verisons the SDKs release for
-python_versions=("3.8" "3.9" "3.10" "3.11" "3.12")
+python_versions=("$@")
 
 # Minimum glibc version we support
 glibc_version=2-32
 
-# These versions are being supported due to the SDKs supporting Python 3.8+
+# These versions are being supported due to the SDKs supporting Python 3.9+
 macOS_version_x86_64=10.9
 macOS_version_arm64=11.0
 
@@ -75,7 +75,7 @@ gh release create "v${version}" --title "Release ${version}" --notes "${release_
 
 # Acquire the wheels for different OS
 for version in "${python_versions[@]}"; do
-pyenv global $version
+pyenv local $version
 build_wheels Darwin x86_64
 build_wheels Darwin arm64
 build_wheels Linux x86_64
@@ -87,7 +87,7 @@ done
 python3 -m build --sdist
 
 # Release on PyPi
-python3 -m twine upload --repository testpypi dist/*
+python3 -m twine upload dist/*
 
 # Delete the dist folder after published
 rm -r dist src/*.egg-info


### PR DESCRIPTION
This MR will update the release scripts to package non-pure python wheels to its correct distro and upload to PyPi.

Currently, it uploads to TestPyPi and its not in the correct file but this is just a test and will be fixed.