### PR TITLE
Direct users to correct Connect SDK.

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Field types:
 
 - [x] [1Password Service Accounts](https://developer.1password.com/docs/service-accounts/get-started/)
 - [ ] User authentication
-- [ ] 1Password Connect. For now, use [1Password/connect-sdk-go](https://github.com/1Password/connect-sdk-go).
+- [ ] 1Password Connect. For now, use [1Password/connect-sdk-python](https://github.com/1Password/connect-sdk-python).
 
 ## 📖 Learn more
 


### PR DESCRIPTION
The README was telling users to use the connect Go SDK on the Python SDK Repo. Updated the readme to direct users towards the Connect Python SDK.