### PR TITLE
Add Optional back to ItemField details field

### DIFF
--- a/src/onepassword/types.py
+++ b/src/onepassword/types.py
@@ -123,7 +123,7 @@ class ItemField(BaseModel):
     """
     The string representation of the field's value
     """
-    details: [ItemFieldDetails]
+    details: Optional[ItemFieldDetails]
     """
     Field type-specific attributes. Must be set to None.
     """


### PR DESCRIPTION
This PR will add back the optional field to `details` in `ItemField`.