### PR TITLE
Update minimum Python version

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 The 1Password Python SDK is compatible with:
 
-- `python` 3.8 or later
+- `python` 3.9 or later
 - `libssl` 3
 - `glibc` 2.32 or later
 


### PR DESCRIPTION
Upon playing around with multiple Python versions, it looks like the SDK is only supported starting Python 3.9, since it requires the `Annotated` feature of the `typing` library which was introduced in 3.9 (see https://docs.python.org/3/library/typing.html#typing.Annotated).

Since Python 3.8 will be deprecated next month (see https://devguide.python.org/versions/) and no customer has yet raised this, we should be okay to bump the minimum required version.