### PR TITLE
Fix example for reading file fields

### DIFF
--- a/example/example.py
+++ b/example/example.py
@@ -350,7 +350,7 @@ async def create_attach_and_delete_file_field_item(client: Client):
     # [developer-docs.sdk.python.read-file-field]-start
     # Read the file field from an item
     content = await client.items.files.read(
-        created_item.vault_id, created_item.id, created_item.files[0]
+        created_item.vault_id, created_item.id, created_item.files[0].attributes
     )
     # [developer-docs.sdk.python.read-file-field]-end
     print(content.decode())


### PR DESCRIPTION
This PR will fix reading a file field example. It is not passing in the correct type which gives us a `data does not match untagged enum....` error.