### PR TITLE
Add Passkeys as unsupported field type to supported functionality list

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,8 +110,9 @@ Field types:
 - [x] Address
 - [x] Date
 - [x] MM/YY
-- [x] Files attachments and Document items
+- [x] File attachments and Document items
 - [x] Menu
+- [ ] Passkeys
 
 ### Vault management
 - [ ] Retrieve vaults


### PR DESCRIPTION
Adds passkeys as an unsupported field type to the list of supported functionality. Also fixes an existing typo.

#174 