### PR TITLE
Update to currently supported manylinux image

### DIFF
--- a/src/release/scripts/build-wheels.sh
+++ b/src/release/scripts/build-wheels.sh
@@ -7,8 +7,9 @@ output_version_file="version.py"
 # The list of python verisons the SDKs release for
 python_versions=("$@")
 
-# Minimum glibc version we support
-glibc_version=2-32
+# Use the currently supported manylinux image greater than our minimum glibc version
+# https://github.com/pypa/manylinux/tree/main
+glibc_version=2-34
 
 # These versions are being supported due to the SDKs supporting Python 3.9+
 macOS_version_x86_64=10.9


### PR DESCRIPTION
https://github.com/pypa/manylinux

The manylinux project supports:

- ``manylinux2014`` images for ``x86_64``, ``i686``, ``aarch64``, ``ppc64le`` and ``s390x``.

- ``manylinux_2_28`` images for ``x86_64``, ``i686``, ``aarch64``, ``ppc64le`` and ``s390x``.

- ``manylinux_2_34`` images for ``x86_64``, ``aarch64``, ``ppc64le`` and ``s390x``.

- ``musllinux_1_2`` images for ``x86_64``, ``i686``, ``aarch64``, ``ppc64le``, ``s390x`` and ``armv7l``.
