### PR TITLE
Improve paths to SDK IPC lib

### DIFF
--- a/src/onepassword/desktop_core.py
+++ b/src/onepassword/desktop_core.py
@@ -23,12 +23,6 @@ def find_1password_lib_path():
 			"/opt/1Password/libop_sdk_ipc_client.so",
 			"/snap/bin/1password/libop_sdk_ipc_client.so",
         ]
-    elif os_name == "Windows":
-        locations = [
-            r"C:\Program Files\1Password\op_sdk_ipc_client.dll",
-			r"C:\Program Files (x86)\1Password\op_sdk_ipc_client.dll",
-            str(Path.home() / r"AppData\Local\1Password\op_sdk_ipc_client.dll"),
-        ]
     else:
         raise OSError(f"Unsupported operating system: {os_name}")
 


### PR DESCRIPTION
This PR does two changes:
- Make the paths to the SDK IPC client on Linux and MacOS more accurate
- Remove support for Windows. This will not be out yet during beta.