### PR TITLE
Add mention of account UUID to desktop auth code comment

### DIFF
--- a/example/desktop_app.py
+++ b/example/desktop_app.py
@@ -13,7 +13,7 @@ async def main():
     # Connects to the 1Password desktop app.
     client = await Client.authenticate(
         auth=DesktopAuth(
-            account_name="YourAccountNameAsShownInTheDesktopApp"  # Set to your 1Password account name as shown at the top left sidebar of the app.
+            account_name="YourAccountNameAsShownInTheDesktopApp"  # Set to your 1Password account name as shown at the top left sidebar of the app, or your account UUID.
         ),
         # Set the following to your own integration name and version.
         integration_name="My 1Password Integration",


### PR DESCRIPTION
This MR adds a mention of the option to specify your account for desktop app authentication with your account UUID, to match the code comments for Go & JS.