### PR TITLE
Support loading a custom shared library path.

### DIFF
--- a/src/onepassword/client.py
+++ b/src/onepassword/client.py
@@ -19,7 +19,9 @@ class Client:
 
     @classmethod
     async def authenticate(
-        cls, auth: str | DesktopAuth, integration_name: str, integration_version: str
+        cls, auth: str | DesktopAuth,
+        integration_name: str, integration_version: str,
+        shared_library_path: str = ""
     ) -> Client:
         config = new_default_config(
             auth=auth,
@@ -28,7 +30,7 @@ class Client:
         )
 
         if isinstance(auth, DesktopAuth):
-            core = DesktopCore(auth.account_name)
+            core = DesktopCore(auth.account_name, shared_library_path)
         else:
             core = UniffiCore()
 

--- a/src/onepassword/desktop_core.py
+++ b/src/onepassword/desktop_core.py
@@ -8,7 +8,7 @@ from ctypes import c_uint8, c_size_t, c_int32, POINTER, byref, c_void_p
 from onepassword.errors import raise_typed_exception
 
 
-def find_1password_lib_path():
+def find_1password_lib_path(custom_location: str = ""):
     os_name = platform.system()
 
     # Define paths based on OS
@@ -32,6 +32,9 @@ def find_1password_lib_path():
         ]
     else:
         raise OSError(f"Unsupported operating system: {os_name}")
+    
+    if isinstance(custom_location, str) and len(custom_location) > 0:
+        locations.insert(0, custom_location)
 
     for lib_path in locations:
         if os.path.exists(lib_path):
@@ -40,9 +43,9 @@ def find_1password_lib_path():
     raise FileNotFoundError("1Password desktop application not found")
 
 class DesktopCore:
-    def __init__(self, account_name: str):
+    def __init__(self, account_name: str, library_path: str = ""):
         # Determine the path to the desktop app.
-        path = find_1password_lib_path()
+        path = find_1password_lib_path(library_path)
 
         self.lib = ctypes.CDLL(path)
         self.account_name = account_name


### PR DESCRIPTION
Adds a `shared_library_path` option to support loading a custom shared library file location.

This is useful for sandboxed contexts (such as nix) which don't have access to the /opt/1Password (or other) directory and must copy the library into the sandbox.

Related SDK PRs:
- https://github.com/1Password/onepassword-sdk-go/pull/231
- https://github.com/1Password/onepassword-sdk-js/pull/169