### PR TITLE
Update beta version format when running the prep-release script

### DIFF
--- a/src/release/scripts/prep-release.sh
+++ b/src/release/scripts/prep-release.sh
@@ -32,14 +32,14 @@ enforce_latest_code() {
     fi
 }
 
-# Function to validate the version number format x.y.z(-beta.w)
+# Function to validate the version number format x.y.z(bw)
 update_and_validate_version() {
     while true; do
         # Prompt the user to input the version number
-        read -p "Enter the version number (format: x.y.z(-beta.w)): " version
+        read -p "Enter the version number (format: x.y.z(bw)): " version
 
         # Validate the version number format
-        if [[ "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-beta\.[0-9]+)?$ ]]; then        
+        if [[ "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(b[0-9]+)?$ ]]; then        
             if [[ "${current_version}" != "${version}" ]]; then
                 # TODO: Check the less than case as well.
                 echo "New version number is: ${version}"
@@ -49,7 +49,7 @@ update_and_validate_version() {
             fi        
         else
             echo "Invalid version number format: ${version}"
-            echo "Please enter a version number in the 'x.y.z(-beta.w)' format."
+            echo "Please enter a version number in the 'x.y.z(bw)' format."
         fi
     done
 }


### PR DESCRIPTION
## Overview

For Python, a beta version has the format `x.y.zbw` (e.g. `0.4.0b2`). 
This PR updates the `prep-release.sh` script to use this format.

## How to test

1. Update the `src/release/scripts/prep-release.sh` and comment the following lines (L111-113):
   ```sh
   git add .
   git commit -S -m "Release v${version}"
   git push --set-upstream origin "${branch}"
   ```
2. Temporarily commit the change.
3. Run `make prep-release`
4. Try to provide a wrong beta version e.g. `0.5.0-beta.1`
    - [ ] It should reject it and ask for the version again.
5. Provide the appropriate beta version e.g. `0.5.0b1`
    - [ ] It should accept it and continue the process.
6. Continue the process (you can ignore editing the release notes)
7. Verify the version stored in `version.py`
   - [ ] It should contain the beta version in the appropriate format. 
8. Reset your branch and remove the temporarily committed changes:
    ```sh
    git reset --hard HEAD~1
    ```