### PR TITLE
Add query parameters to 'Create a service account' links 

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ If you're running a Linux distribution that still uses `libssl` version 1.1.1, s
 
 To use the 1Password Python SDK in your project:
 
-1. [Create a service account](https://my.1password.com/developer-tools/infrastructure-secrets/serviceaccount/) and give it the appropriate permissions in the vaults where the items you want to use with the SDK are saved.
+1. [Create a service account](https://my.1password.com/developer-tools/infrastructure-secrets/serviceaccount/?source=github-sdk) and give it the appropriate permissions in the vaults where the items you want to use with the SDK are saved.
 2. Provision your service account token. We recommend provisioning your token from the environment. For example, to export your token to the `OP_SERVICE_ACCOUNT_TOKEN` environment variable:
 
    **macOS or Linux**


### PR DESCRIPTION
RELATES TO: [DG-556](https://gitlab.1password.io/dev/b5/b5/-/merge_requests/31595)

The above MR is a telemetry event whose goal is to track when the service account wizard (b5) is viewed and how the user has arrived at the wizard (AKA source). To better track where a user is coming from, I've implemented new query params in the [developer portal links](https://gitlab.1password.io/dev/web/developer.1password.com/-/merge_requests/1534), and want to do the same for the SDK README files.