### PR TITLE
Add PyInstaller Hook to Collect Binaries

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,11 @@ setup(
     license_files="LICENSE",
     package_dir={"": "src"},
     python_requires=">=3.9",
+    entry_points={
+        "pyinstaller40": [
+            "hook-dirs = onepassword.pyinstaller_hooks:get_hook_dirs",
+        ],
+    },
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Operating System :: MacOS",
@@ -76,5 +81,6 @@ setup(
     package_data={"": get_shared_library_data_to_include()},
     install_requires=[
         "pydantic>=2.5",  # Minimum Pydantic version to run the Python SDK
+        "pyinstaller>=6.18.0"
     ],
 )

--- a/src/onepassword/pyinstaller_hooks/__init__.py
+++ b/src/onepassword/pyinstaller_hooks/__init__.py
@@ -1,0 +1,5 @@
+import os
+
+
+def get_hook_dirs():
+    return [os.path.dirname(__file__)]

--- a/src/onepassword/pyinstaller_hooks/hook-onepassword.py
+++ b/src/onepassword/pyinstaller_hooks/hook-onepassword.py
@@ -1,0 +1,3 @@
+from PyInstaller.utils.hooks import collect_dynamic_libs
+
+binaries = collect_dynamic_libs("onepassword")


### PR DESCRIPTION
When onepassword is imported, running an executable generated by PyInstaller (on Windows) will fail at runtime, unless the required binary `op_uniffi_core.dll` is manually added to a .spec file, or with the --add-binary flag. I believe this happens as the required .dll binary file is not automatically detected by PyInstaller. 

### Reproduction
```
pip install onepassword-sdk pyinstaller
echo "import onepassword" > test.py
pyinstaller test.py
./dist/test/test.exe
```
The resulting error: 
```
Traceback (most recent call last):
  File "test.py", line 1, in <module>
    import onepassword
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
  File "pyimod02_importers.py", line 457, in exec_module
  File "onepassword\__init__.py", line 3, in <module>
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
  File "pyimod02_importers.py", line 457, in exec_module
  File "onepassword\client.py", line 5, in <module>
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
  File "pyimod02_importers.py", line 457, in exec_module
  File "onepassword\core.py", line 14, in <module>
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
  File "pyimod02_importers.py", line 457, in exec_module
  File "onepassword\lib\x86_64\op_uniffi_core.py", line 492, in <module>
  File "onepassword\lib\x86_64\op_uniffi_core.py", line 468, in _uniffi_load_indirect
  File "ctypes\__init__.py", line 471, in LoadLibrary
  File "pyimod03_ctypes.py", line 55, in __init__
pyimod03_ctypes.install.<locals>.PyInstallerImportError: Failed to load dynlib/dll 'C:..\\onepassword\\dist\\test\\_internal\\onepassword\\lib\\x86_64\\op_uniffi_core.dll'. Most likely this dynlib/dll was not found when the application was frozen.
[PYI-10644:ERROR] Failed to execute script 'test' due to unhandled exception!
```
### Solution
This PR adds a PyInstaller hook `hook-onepassword.py` that collects required binaries so they are bundled automatically when building an executable. Build output confirms the hook is detected:
```
INFO: Processing standard module hook 'hook-onepassword.py' from 'C:...\\onepassword\\venv\\Lib\\site-packages\\onepassword\\pyinstaller_hooks'
```
This is not particularly urgent, but a nice to have!