### PR TITLE
Update Integration Tests

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -123,8 +123,8 @@ jobs:
     - name: Example Test
       if: matrix.os == 'ubuntu-latest'
       env:
-        OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.TEST_SERVICE_ACCOUNT_TOKEN }}
-        OP_VAULT_ID: ${{ secrets.TEST_SERVICE_ACCOUNT_VAULT_ID }}
+        OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.EXAMPLE_TESTS_OP_SERVICE_ACCOUNT_TOKEN }}
+        OP_VAULT_ID: ${{ secrets.EXAMPLE_TESTS_OP_VAULT_ID }}
       run: |
         pip install . &&
         python example/example.py

--- a/src/onepassword/test_client.py
+++ b/src/onepassword/test_client.py
@@ -18,7 +18,7 @@ async def test_valid_resolve():
         integration_version=onepassword_defaults.DEFAULT_INTEGRATION_VERSION,
     )
     result = await client.secrets.resolve(
-        secret_reference="op://gowwbvgow7kxocrfmfvtwni6vi/6ydrn7ne6mwnqc2prsbqx4i4aq/password"
+        secret_reference="op://dm42px5dmgusczoarfdubfmodm/2fwfzpvjvaey2lwph5jupovjaq/password"
     )
     assert result == "test_password_42"
 


### PR DESCRIPTION
The old test account is being deleted, so the integration test now points at a new vault. Matches the equivalent change in the JS SDK.

- src/onepassword/test_client.py: updated the hardcoded secret reference to the new vault and item.
- .github/workflows/validate.yml — the fork job's example step referenced TEST_SERVICE_ACCOUNT_VAULT_ID, which doesn't exist as a repo secret, so that step has never worked. Repointed it at EXAMPLE_TESTS_OP_SERVICE_ACCOUNT_TOKEN / EXAMPLE_TESTS_OP_VAULT_ID, matching the trusted job. 