### PR TITLE
Add CPython 3.14 to the supported wheel matrix

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Harden the runner (Audit all outbound calls)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PYTHON_VERSIONS := 3.9 3.10 3.11 3.12 3.13
+PYTHON_VERSIONS := 3.9 3.10 3.11 3.12 3.13 3.14
 
 release:
 	src/release/scripts/release.sh
@@ -21,4 +21,3 @@ release/install-dependencies:
 		pyenv local $$version; \
 		pyenv exec pip3 install wheel setuptools build --break-system-packages; \
 	done
-

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,11 @@
-from pathlib import Path
-from setuptools import setup, find_packages
-from sysconfig import get_platform
-from version import SDK_VERSION
-import platform
 import os
+import platform
+from pathlib import Path
+from sysconfig import get_platform
+
+from setuptools import find_packages, setup
+
+from version import SDK_VERSION
 
 try:
     from wheel.bdist_wheel import bdist_wheel as _bdist_wheel
@@ -70,6 +72,7 @@ setup(
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14",
         "License :: OSI Approved :: MIT License",
     ],
     cmdclass={"bdist_wheel": bdist_wheel},

--- a/src/release/scripts/build-wheels.sh
+++ b/src/release/scripts/build-wheels.sh
@@ -51,7 +51,7 @@ build_wheels() {
             python_version=$(pyenv exec python3 --version 2>&1)
 
             if [[ "$machine_platform" == "x86_64" ]]; then
-                if [[ "$python_version" == "Python 3.13"* ]]; then
+                if [[ "$python_version" =~ ^Python\ 3\.(1[3-9]|[2-9][0-9]) ]]; then
                 macos_version="10.13"
             else
                 macos_version=$macOS_version_x86_64


### PR DESCRIPTION
## Summary

- add CPython 3.14 to the supported classifier and trusted validation matrix
- include 3.14 in the release wheel version list
- keep the macOS x86_64 deployment-target comparison valid for Python 3.14+

This is the upstreamable portion of the temporary Atlaso compatibility work and addresses #244. The fork-specific build and release pipeline is intentionally excluded.

## Validation

- `python -m ruff check setup.py`
- `bash -n src/release/scripts/build-wheels.sh`
- local Windows CPython 3.14 wheel build from the exact 0.4.1 sdist
- clean import and UniFFI/DLL contract validation on standard Windows x64 CPython 3.14